### PR TITLE
Fix `nonce` generation in python

### DIFF
--- a/src/python/auth.py
+++ b/src/python/auth.py
@@ -1,34 +1,34 @@
-import json
 import base64
-import requests
-import time
-import hmac
 import hashlib
+import hmac
+import json
+import time
+
+import requests
 
 
-api_key = '' #put here your public key
-secret_key = '' #put here your secret key
-request = '/api/v4/trade-account/balance' #put here request path. For obtaining trading balance use: /api/v4/trade-account/balance
-baseUrl = 'https://whitebit.com' #domain without last slash. Do not use https://whitebit.com/
-#If the nonce is similar to or lower than the previous request number, you will receive the 'too many requests' error message
-nonce = str(int(time.time())) #nonce is a number that is always higher than the previous request number
-
+api_key = ''  # put here your public key
+secret_key = ''  # put here your secret key
+request = '/api/v4/trade-account/balance'  # put here request path. For obtaining trading balance use: /api/v4/trade-account/balance
+baseUrl = 'https://whitebit.com'  # domain without last slash. Do not use https://whitebit.com/
+# If the nonce is similar to or lower than the previous request number, you will receive the 'too many requests' error message
+nonce = time.time_ns() // 1_000_000  # nonce is a number (preferrably epoch time in milliseconds) that is always higher than the previous request number
 
 data = {
-  'ticker': 'BTC', #for example for obtaining trading balance for BTC currency
-  'request': request,
-  'nonce': nonce,
-    'nonceWindow': True # the api will validate that your nonce enter the range of current time +/- 5 seconds
+    'ticker': 'BTC',  # for example for obtaining trading balance for BTC currency
+    'request': request,
+    'nonce': nonce,
+    'nonceWindow': True  # the api will validate that your nonce enter the range of current time +/- 5 seconds
 }
 
-#preparing request URL
+# preparing request URL
 completeUrl = baseUrl + request
 
-data_json = json.dumps(data, separators=(',', ':')) #use separators param for deleting spaces
+data_json = json.dumps(data, separators=(',', ':'))  # use separators param for deleting spaces
 payload = base64.b64encode(data_json.encode('ascii'))
 signature = hmac.new(secret_key.encode('ascii'), payload, hashlib.sha512).hexdigest()
 
-#preparing headers
+# preparing headers
 headers = {
     'Content-type': 'application/json',
     'X-TXC-APIKEY': api_key,
@@ -36,8 +36,8 @@ headers = {
     'X-TXC-SIGNATURE': signature,
 }
 
-#sending request
+# sending request
 resp = requests.post(completeUrl, headers=headers, data=data_json)
 
-#receiving data
+# receiving data
 print(json.dumps(resp.json(), sort_keys=True, indent=4))


### PR DESCRIPTION
Current nonce generation in [python](https://github.com/whitebit-exchange/api-quickstart/blob/6e2b2b14f7dffc47615544f43c1eb66b51c3fb96/src/python/auth.py#L14) is not valid and returns:
```
{
    "code": 0,
    "message": "Your nonce is more than 5 seconds lesser than the current nonce."
}
```
This happens because `str(int(time.time()))` generates current epoch time in **seconds**, and we need to pass nonce in **milliseconds**, as specified [here](https://github.com/whitebit-exchange/api-docs/blame/main/docs/Private/http-auth.md#L22).
 
Therefore, we have two options to fix this:
1. `time.time_ns() // 1_000_000`
2. `int(time.time()) * 1000`

I prefer the first one and propose to accept current PR which fixes the nonce generation.

Best regards,
Daniil Bykov aka [Danipulok](https://github.com/Danipulok).

